### PR TITLE
53 utilize localstorage

### DIFF
--- a/spotify.js
+++ b/spotify.js
@@ -101,11 +101,42 @@ document.getElementById('spotify-search').addEventListener('submit', async (e) =
         headers: { 'Authorization': `Bearer ${token}` },        
        });
     const artistData = await artistResponse.json(); 
-    localStorage.setItem('artist-name', query);
+    localStorage.setItem('storedName', query); // save user input to localStorage
     updateDisplay(artistData, albums);// display results
 });
 
 
+// HANDLE LOCALSTORAGE CHECK
+window.addEventListener('load', async (e) => { 
+    const storedName = localStorage.getItem('storedName');
+        console.log("Stored name:" + " " + storedName);
+    if(!storedName) return; // if none found, return
+
+    const token = await getToken(); // get access token and create resource
+    const artistID = await searchStoredName(storedName, token); // get ID from storedName in local storage
+    const albums = await getAlbums(artistID, token); // get artist's albums
+    const artistResponse = await fetch(`https://api.spotify.com/v1/artists/${artistID}`, {
+        method: 'GET',
+        headers: { 'Authorization': `Bearer ${token}` },        
+       });
+    const artistData = await artistResponse.json(); 
+    updateDisplay(artistData, albums); // display results
+});
+
+
+// HANDLE ARTIST SEARCH FROM LOCAL STORAGE NAME
+async function searchStoredName(storedName, token) { 
+    const response = await fetch(`https://api.spotify.com/v1/search?q=${storedName}&type=artist&limit=1`, {
+        method: 'GET',
+        headers: { 'Authorization': `Bearer ${token}` },
+    });
+
+    const data = await response.json();
+    const artist = data.artists.items[0];
+    const artistID = artist.id;
+    console.log('Search Response:', artist); // Log the search results JSON response
+    return artist.id; // return artist ID
+};
 
 //NOTES
     // DOCUMENTATION: https://developer.spotify.com/documentation/web-api/concepts/api-calls

--- a/spotify.js
+++ b/spotify.js
@@ -101,7 +101,7 @@ document.getElementById('spotify-search').addEventListener('submit', async (e) =
         headers: { 'Authorization': `Bearer ${token}` },        
        });
     const artistData = await artistResponse.json(); 
-
+    localStorage.setItem('artist-name', query);
     updateDisplay(artistData, albums);// display results
 });
 

--- a/ticket.js
+++ b/ticket.js
@@ -29,6 +29,7 @@ function getUniqueArtists(events, count) {
         }
         if (uniqueArtistEvents.length >= count) break;
     }
+    
     return uniqueArtistEvents;
 }
 
@@ -49,6 +50,7 @@ searchForm.addEventListener("submit", function(event) {
     const artistName = searchInput.value.trim();
     if (artistName) {
         searchArtist(artistName);
+        localStorage.setItem('artist-name', artistName); // save user input to localStorage
     }
 });
 
@@ -57,6 +59,7 @@ async function searchArtist(artistName) {
         const response = await fetch(`https://app.ticketmaster.com/discovery/v2/events.json?apikey=${apiKey}&classificationName=Music&keyword=${artistName}&countryCode=US&size=10`);
         const data = await response.json();
         if (data._embedded && data._embedded.events) {
+            console.log(data);
             displayEvents(data._embedded.events);
         } else {
             lineupGrid.innerHTML = `<p>No events found for "${artistName}".</p>`;

--- a/ticket.js
+++ b/ticket.js
@@ -50,7 +50,7 @@ searchForm.addEventListener("submit", function(event) {
     const artistName = searchInput.value.trim();
     if (artistName) {
         searchArtist(artistName);
-        localStorage.setItem('artist-name', artistName); // save user input to localStorage
+        localStorage.setItem('storedName', artistName); // save user input to localStorage
     }
 });
 

--- a/ticket.js
+++ b/ticket.js
@@ -69,6 +69,34 @@ async function searchArtist(artistName) {
     }
 }
 
-fetchEvents();
 
 
+//// CODE FOR RETRIEVING LOCALSTORAGE DATA ////
+
+// on page load, check for storedName in local storage
+window.addEventListener('load', async (e) => {
+    const storedName = localStorage.getItem('storedName');
+        console.log("Stored name:" + " " + storedName);
+    if(storedName) { // if storedName is found
+        searchStoredName(storedName); // run function to search by stored name
+    } else {
+        fetchEvents(); // otherwise, fetchEvents
+    }
+});
+
+
+// search by stored name
+async function searchStoredName(storedName) {
+    try {
+        const response = await fetch(`https://app.ticketmaster.com/discovery/v2/events.json?apikey=${apiKey}&classificationName=Music&keyword=${storedName}&countryCode=US&size=10`);
+        const data = await response.json();
+        if (data._embedded && data._embedded.events) {
+            console.log(data);
+            displayEvents(data._embedded.events);
+        } else {
+            lineupGrid.innerHTML = `<p>No events found for "${storedName}".</p>`;
+        }
+    } catch (error) {
+        lineupGrid.innerHTML = `<p>Failed to load events for "${storedName}". Please try again later.</p>`;
+    }
+};


### PR DESCRIPTION
With this update, the ticket.js and spotify.js should:
- store user input from either API page as storedName in localStorage 
- if either page finds a previous search term (storedName), they will automatically load content for that artist
- if there is no storedName found, the spotify page will show a search bar and the ticketmaster page will run the fetchEvents() function like it was before


let me know if this works for you or if you catch any bugs!